### PR TITLE
fix(clippy): Fix clippy warnings for `uninlined-format-args`

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -14,9 +14,9 @@ use std::{ffi::OsStr, fmt::Display, fmt::Write, path::Path, str};
 
 fn emit(directive: &str, value: impl Display) {
     if allow_use::double_colon_directives() {
-        println!("cargo::{}={}", directive, value);
+        println!("cargo::{directive}={value}");
     } else {
-        println!("cargo:{}={}", directive, value);
+        println!("cargo:{directive}={value}");
     }
 }
 
@@ -96,7 +96,7 @@ pub fn rustc_link_arg_bin(bin: &str, flag: &str) {
     if flag.contains([' ', '\n']) {
         panic!("cannot emit rustc-link-arg-bin: invalid flag {flag:?}");
     }
-    emit("rustc-link-arg-bin", format_args!("{}={}", bin, flag));
+    emit("rustc-link-arg-bin", format_args!("{bin}={flag}"));
 }
 
 /// The `rustc-link-arg-bins` instruction tells Cargo to pass the
@@ -401,7 +401,7 @@ pub fn metadata(key: &str, val: &str) {
     }
 
     if allow_use::double_colon_directives() {
-        emit("metadata", format_args!("{}={}", key, val));
+        emit("metadata", format_args!("{key}={val}"));
     } else {
         emit(key, val);
     }


### PR DESCRIPTION
In the latest version of clippy, warnings were generated,

```
   |
16 |     println!("cargo::{}={}", directive, value);
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
   = note: `-D clippy::uninlined-format-args` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::uninlined_format_args)]`
help: change this to
   |
16 -     println!("cargo::{}={}", directive, value);
16 +     println!("cargo::{directive}={value}");
   |

error: variables can be used directly in the `format!` string
   --> crates/build-rs/src/output.rs:100:32
    |
100 |     emit("rustc-link-arg-bin", format_args!("{}={}", bin, flag));
    |                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
help: change this to
    |
100 -     emit("rustc-link-arg-bin", format_args!("{}={}", bin, flag));
100 +     emit("rustc-link-arg-bin", format_args!("{bin}={flag}"));
    |

error: variables can be used directly in the `format!` string
   --> crates/build-rs/src/output.rs:436:22
    |
436 |     emit("metadata", format_args!("{}={}", key, val));
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
help: change this to
    |
436 -     emit("metadata", format_args!("{}={}", key, val));
436 +     emit("metadata", format_args!("{key}={val}"));
    |
```

This PR fixes these warnings by applying the suggested changes